### PR TITLE
Fix missing page exports

### DIFF
--- a/tucker-vercel-project/src/app/about/page.tsx
+++ b/tucker-vercel-project/src/app/about/page.tsx
@@ -1,0 +1,8 @@
+export default function AboutPage() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold">About BikeShare</h1>
+      <p className="mt-4 text-gray-600">More information will be available soon.</p>
+    </main>
+  );
+}

--- a/tucker-vercel-project/src/app/bike/[id]/page.tsx
+++ b/tucker-vercel-project/src/app/bike/[id]/page.tsx
@@ -1,0 +1,13 @@
+import { useParams } from 'next/navigation';
+
+export default function BikeDetailsPage() {
+  const params = useParams<{ id: string }>();
+  const id = params?.id;
+
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold">Bike {id}</h1>
+      <p className="mt-4 text-gray-600">Details for bike {id} will go here.</p>
+    </main>
+  );
+}

--- a/tucker-vercel-project/src/app/browse/page.tsx
+++ b/tucker-vercel-project/src/app/browse/page.tsx
@@ -1,0 +1,8 @@
+export default function BrowsePage() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold">Browse Bikes</h1>
+      <p className="mt-4 text-gray-600">Browse available bikes here.</p>
+    </main>
+  );
+}

--- a/tucker-vercel-project/src/app/list-bike/page.tsx
+++ b/tucker-vercel-project/src/app/list-bike/page.tsx
@@ -1,0 +1,8 @@
+export default function ListBikePage() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold">List Your Bike</h1>
+      <p className="mt-4 text-gray-600">Feature coming soon.</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholder pages for all routes
- fix use of router params in the dynamic bike page

## Testing
- `npm run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e393dc748330a276ab75a3555e5a