### PR TITLE
Add interactive component tests

### DIFF
--- a/tucker-vercel-project/__tests__/interactive-heading.test.tsx
+++ b/tucker-vercel-project/__tests__/interactive-heading.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import InteractiveHeading from '../src/components/InteractiveHeading';
+import { waitForElementToBeRemoved } from '@testing-library/react';
+
+describe('InteractiveHeading component', () => {
+  test('updates heading text based on user input', async () => {
+    render(<InteractiveHeading />);
+    const input = screen.getByLabelText('text-input');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'World');
+    expect(screen.getByRole('heading', { name: 'World' })).toBeInTheDocument();
+  });
+
+  test('removes heading when toggle button clicked', async () => {
+    render(<InteractiveHeading />);
+    const button = screen.getByLabelText('toggle-heading');
+    const heading = screen.getByRole('heading', { name: 'Hello' });
+    await userEvent.click(button);
+    await waitForElementToBeRemoved(heading);
+  });
+});

--- a/tucker-vercel-project/src/components/InteractiveHeading.tsx
+++ b/tucker-vercel-project/src/components/InteractiveHeading.tsx
@@ -1,0 +1,17 @@
+'use client'
+import { useState } from 'react';
+
+export default function InteractiveHeading() {
+  const [text, setText] = useState('Hello');
+  const [visible, setVisible] = useState(true);
+
+  return (
+    <div>
+      <input aria-label="text-input" value={text} onChange={e => setText(e.target.value)} />
+      <button onClick={() => setVisible(v => !v)} aria-label="toggle-heading">
+        Toggle
+      </button>
+      {visible && <h1>{text}</h1>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `InteractiveHeading` component with a toggle and text input
- test heading update and removal behaviors using React Testing Library

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503ec5848483308479973f81711313