### PR TITLE
Add interactive bike list test

### DIFF
--- a/tucker-vercel-project/__tests__/bike-list.test.tsx
+++ b/tucker-vercel-project/__tests__/bike-list.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BikeList from '../src/components/BikeList';
+
+describe('\ud83c\udfcd\ufe0f\ufe0f BikeList component', () => {
+  test('hides already-rented bikes when "Show rented" is toggled off', async () => {
+    render(<BikeList />);
+
+    expect(screen.getByRole('heading', { name: /Featured Bikes/i })).toBeInTheDocument();
+    expect(screen.getByText(/Vintage Cruiser/i)).toBeInTheDocument();
+
+    const toggle = screen.getByLabelText('Show rented');
+    await userEvent.click(toggle);
+
+    expect(screen.queryByText(/Vintage Cruiser/i)).not.toBeInTheDocument();
+  });
+
+  test('shows rented bikes again when toggled back on', async () => {
+    render(<BikeList />);
+    const toggle = screen.getByLabelText('Show rented');
+
+    await userEvent.click(toggle); // hide rented bikes
+    await userEvent.click(toggle); // show again
+
+    expect(screen.getByText(/Vintage Cruiser/i)).toBeInTheDocument();
+  });
+});

--- a/tucker-vercel-project/__tests__/interactive-heading.test.tsx
+++ b/tucker-vercel-project/__tests__/interactive-heading.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import InteractiveHeading from '../src/components/InteractiveHeading';
+import { waitForElementToBeRemoved } from '@testing-library/react';
+
+describe('InteractiveHeading component', () => {
+  test('updates heading text based on user input', async () => {
+    render(<InteractiveHeading />);
+    const input = screen.getByLabelText('text-input');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'World');
+    expect(screen.getByRole('heading', { name: 'World' })).toBeInTheDocument();
+  });
+
+  test('removes heading when toggle button clicked', async () => {
+    render(<InteractiveHeading />);
+    const button = screen.getByLabelText('toggle-heading');
+    screen.getByRole('heading', { name: 'Hello' });
+    await userEvent.click(button);
+    await waitForElementToBeRemoved(() =>
+      screen.queryByRole('heading', { name: 'Hello' })
+    );
+  });
+});

--- a/tucker-vercel-project/src/components/BikeList.tsx
+++ b/tucker-vercel-project/src/components/BikeList.tsx
@@ -1,0 +1,40 @@
+'use client'
+import { useState } from 'react';
+
+interface Bike {
+  id: number;
+  name: string;
+  rented: boolean;
+}
+
+const bikes: Bike[] = [
+  { id: 1, name: 'Mountain Adventurer', rented: false },
+  { id: 2, name: 'Vintage Cruiser', rented: true },
+  { id: 3, name: 'City Commuter', rented: false }
+];
+
+export default function BikeList() {
+  const [showRented, setShowRented] = useState(true);
+
+  const visibleBikes = bikes.filter(bike => showRented || !bike.rented);
+
+  return (
+    <div>
+      <h2>Featured Bikes</h2>
+      <label>
+        <input
+          type="checkbox"
+          aria-label="Show rented"
+          checked={showRented}
+          onChange={() => setShowRented(v => !v)}
+        />
+        Show rented
+      </label>
+      <ul>
+        {visibleBikes.map(bike => (
+          <li key={bike.id}>{bike.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/tucker-vercel-project/src/components/InteractiveHeading.tsx
+++ b/tucker-vercel-project/src/components/InteractiveHeading.tsx
@@ -1,0 +1,17 @@
+'use client'
+import { useState } from 'react';
+
+export default function InteractiveHeading() {
+  const [text, setText] = useState('Hello');
+  const [visible, setVisible] = useState(true);
+
+  return (
+    <div>
+      <input aria-label="text-input" value={text} onChange={e => setText(e.target.value)} />
+      <button onClick={() => setVisible(v => !v)} aria-label="toggle-heading">
+        Toggle
+      </button>
+      {visible && <h1>{text}</h1>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create a `BikeList` component showing bikes with a toggle for rented items
- verify list hides rented bikes and shows them again when toggled

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503ec5848483308479973f81711313